### PR TITLE
feat: add editorconfig and prettier

### DIFF
--- a/next-ssr-app/.editorconfig
+++ b/next-ssr-app/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+

--- a/next-ssr-app/.eslintrc.json
+++ b/next-ssr-app/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "next/core-web-vitals",
+    "prettier"
+  ]
 }

--- a/next-ssr-app/.prettierignore
+++ b/next-ssr-app/.prettierignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/next-ssr-app/.prettierrc.js
+++ b/next-ssr-app/.prettierrc.js
@@ -1,0 +1,23 @@
+const config= {
+  $schema: 'https://json.schemastore.org/prettierrc',
+  printWidth: 120, // 一行最多 120 字符
+  tabWidth: 2, // 使用 2 个空格缩进
+  useTabs: false, // 不使用缩进符，而使用空格
+  semi: true, // 行尾需要有分号
+  singleQuote: true, // 使用单引号
+  quoteProps: 'as-needed', // 对象的 key 仅在必要时用引号
+  jsxSingleQuote: false, // jsx 不使用单引号，而使用双引号
+  trailingComma: 'all', // 末尾不需要逗号
+  bracketSpacing: true, // 大括号内的首尾需要空格
+  bracketSameLine: false, // jsx 标签的反尖括号需要换行
+  arrowParens: 'always', // 箭头函数，只有一个参数的时候，也需要括号
+  rangeStart: 0, // 每个文件格式化的范围是文件的全部内容
+  rangeEnd: Infinity,
+  requirePragma: false, // 不需要写文件开头的 @prettier
+  insertPragma: false, // 不需要自动在文件开头插入 @prettier
+  proseWrap: 'preserve', // 使用默认的折行标准
+  htmlWhitespaceSensitivity: 'css', // 根据显示样式决定 html 要不要折行
+  endOfLine: 'lf', // 换行符使用 lf
+};
+
+module.exports =  config

--- a/next-ssr-app/package.json
+++ b/next-ssr-app/package.json
@@ -9,10 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@types/md5": "^2.3.2",
-    "@types/node": "20.5.7",
-    "@types/react": "18.2.21",
-    "@types/react-dom": "18.2.7",
     "antd": "^5.8.5",
     "axios": "^1.5.0",
     "date-fns": "^2.30.0",
@@ -23,10 +19,18 @@
     "mockjs": "^1.1.0",
     "next": "13.4.19",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "5.2.2"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "sass": "^1.66.1"
+    "@types/md5": "^2.3.2",
+    "@types/node": "20.5.7",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.48.0",
+    "eslint-config-next": "13.4.19",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "3.0.3",
+    "sass": "^1.66.1",
+    "typescript": "5.2.2"
   }
 }


### PR DESCRIPTION
# Ensure file format and code format consistency for multi-person collaboration

> in jetbrains IDE:

- editorconfig is default

- prettier need open by ：Setting | Languages & Frameworks | JavaScript | Prettier.

> in vscode :

- editroconfig need install plugin [editroconfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)

- prettier need install plugin [prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
